### PR TITLE
Add Chef 10.x compatibility when making PUT request

### DIFF
--- a/libraries/rekey.rb
+++ b/libraries/rekey.rb
@@ -75,7 +75,11 @@ class Chef
       end
 
       def update
-        response = http_api.put("clients/#{name}", put_data)
+        response = if http_api.respond_to?(:put)
+                     http_api.put("clients/#{name}", put_data)
+                   else
+                     http_api.put_rest("clients/#{name}", put_data)
+                   end
         if response.respond_to?(:private_key) # Chef 11
           @server_generated_private_key = response.private_key
         else # Chef 10


### PR DESCRIPTION
In Chef 10.x client the put method is called `put_rest` so we call one or each other depending of version.
