### PR TITLE
Changed to Chef::ServerAPI from Chef::REST as Chef::REST is deprecated

### DIFF
--- a/libraries/rekey.rb
+++ b/libraries/rekey.rb
@@ -97,7 +97,16 @@ class Chef
       end
 
       def http_api
-        @http_api ||= Chef::REST.new(Chef::Config[:chef_server_url])
+        if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.7.0')
+          @http_api ||= Chef::REST::RestRequest.new(Chef::Config[:chef_server_url])
+        else
+          @http_api ||= Chef::ServerAPI.new(
+            Chef::Config[:chef_server_url],
+            api_version: '0',
+            client_name: Chef::Config[:client_name],
+            signing_key_filename: Chef::Config[:client_key]
+          )
+        end
       end
 
       # Whether or not to generate keys locally and post the public key to the

--- a/libraries/rekey.rb
+++ b/libraries/rekey.rb
@@ -97,16 +97,21 @@ class Chef
       end
 
       def http_api
-        if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.7.0')
-          @http_api ||= Chef::REST::RestRequest.new(Chef::Config[:chef_server_url])
-        else
-          @http_api ||= Chef::ServerAPI.new(
-            Chef::Config[:chef_server_url],
-            api_version: '0',
-            client_name: Chef::Config[:client_name],
-            signing_key_filename: Chef::Config[:client_key]
-          )
-        end
+        #  dep_version = Gem::Version.new('12.7.0')
+        # running_version = Gem::Version.new(Chef::VERSION)
+        # rc = Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.7.0')
+        # if running_version < dep_version
+        #  @http_api ||= Chef::REST::RestRequest.new(Chef::Config[:chef_server_url])
+        @http_api = if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.7.0')
+                      Chef::REST::RestRequest.new(Chef::Config[:chef_server_url])
+                    else
+                      @http_api ||= Chef::ServerAPI.new(
+                        Chef::Config[:chef_server_url],
+                        api_version: '0',
+                        client_name: Chef::Config[:client_name],
+                        signing_key_filename: Chef::Config[:client_key]
+                      )
+                    end
       end
 
       # Whether or not to generate keys locally and post the public key to the


### PR DESCRIPTION
### Description

I was running into the error "Uninitialized constant Chef::REST" when trying to use this cookbook with chef client 12.11.18.  Chef::REST looks like it was deprecated in 12.7.

I'm not sure if this is the best approach for resolving this as I am fairly new to ruby programming
### Issues Resolved

Chef::REST is deprecated resulting in the chef run failing with uninitialized constant
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
